### PR TITLE
✨feat: Add maxLines, maxTokens and temperature settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
           },
           "inference.maxLines": {
             "type": "number",
-            "default": 16
+            "default": 16,
+            "description": "Max number of lines to be keep."
           },
           "inference.maxTokens": {
             "type": "number",
-            "default": 256
+            "default": 256,
+            "description": "Max number of new tokens to be generated."
           },
           "inference.model": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,14 @@
             "default": "http://127.0.0.1:11434/",
             "description": "Ollama Server Endpoint"
           },
+          "inference.maxLines": {
+            "type": "number",
+            "default": 16
+          },
+          "inference.maxTokens": {
+            "type": "number",
+            "default": 256
+          },
           "inference.model": {
             "type": "string",
             "enum": [

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
             "default": 256,
             "description": "Max number of new tokens to be generated."
           },
+          "inference.temperature": {
+            "type": "number",
+            "default": 0.2,
+            "description": "Temperature of the model. Increasing the temperature will make the model answer more creatively."
+          },
           "inference.model": {
             "type": "string",
             "enum": [

--- a/src/prompts/autocomplete.ts
+++ b/src/prompts/autocomplete.ts
@@ -8,6 +8,8 @@ export async function autocomplete(args: {
     model: string,
     prefix: string,
     suffix: string,
+    maxLines: number,
+    maxTokens: number,
     canceled?: () => boolean,
 }): Promise<string> {
 
@@ -17,7 +19,7 @@ export async function autocomplete(args: {
         prompt: adaptPrompt({ prefix: args.prefix, suffix: args.suffix, model: args.model }),
         raw: true,
         options: {
-            num_predict: 256
+            num_predict: args.maxTokens
         }
     };
 
@@ -75,9 +77,8 @@ export async function autocomplete(args: {
 
         // Update total lines
         totalLines += countSymbol(tokens.response, '\n');
-
         // Break if too many lines and on top level
-        if (totalLines > 16 && blockStack.length === 0) {
+        if (totalLines > args.maxLines && blockStack.length === 0) {
             info('Too many lines, breaking.');
             break;
         }

--- a/src/prompts/autocomplete.ts
+++ b/src/prompts/autocomplete.ts
@@ -10,6 +10,7 @@ export async function autocomplete(args: {
     suffix: string,
     maxLines: number,
     maxTokens: number,
+    temperature: number,
     canceled?: () => boolean,
 }): Promise<string> {
 
@@ -19,7 +20,8 @@ export async function autocomplete(args: {
         prompt: adaptPrompt({ prefix: args.prefix, suffix: args.suffix, model: args.model }),
         raw: true,
         options: {
-            num_predict: args.maxTokens
+            num_predict: args.maxTokens,
+            temperature: args.temperature
         }
     };
 

--- a/src/prompts/provider.ts
+++ b/src/prompts/provider.ts
@@ -67,6 +67,7 @@ export class PromptProvider implements vscode.InlineCompletionItemProvider {
                     let model = config.get('model') as string;
                     let maxLines = config.get('maxLines') as number;
                     let maxTokens = config.get('maxTokens') as number;
+                    let temperature = config.get('temperature') as number;
                     if (endpoint.endsWith('/')) {
                         endpoint = endpoint.slice(0, endpoint.length - 1);
                     }
@@ -102,6 +103,7 @@ export class PromptProvider implements vscode.InlineCompletionItemProvider {
                             model: model,
                             maxLines: maxLines,
                             maxTokens: maxTokens,
+                            temperature,
                             canceled: () => token.isCancellationRequested,
                         });
                         info(`AI completion completed: ${res}`);

--- a/src/prompts/provider.ts
+++ b/src/prompts/provider.ts
@@ -65,6 +65,8 @@ export class PromptProvider implements vscode.InlineCompletionItemProvider {
                     let config = vscode.workspace.getConfiguration('inference');
                     let endpoint = config.get('endpoint') as string;
                     let model = config.get('model') as string;
+                    let maxLines = config.get('maxLines') as number;
+                    let maxTokens = config.get('maxTokens') as number;
                     if (endpoint.endsWith('/')) {
                         endpoint = endpoint.slice(0, endpoint.length - 1);
                     }
@@ -98,6 +100,8 @@ export class PromptProvider implements vscode.InlineCompletionItemProvider {
                             suffix: prepared.suffix,
                             endpoint: endpoint,
                             model: model,
+                            maxLines: maxLines,
+                            maxTokens: maxTokens,
                             canceled: () => token.isCancellationRequested,
                         });
                         info(`AI completion completed: ${res}`);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -17,12 +17,16 @@ suite('Extension Test Suite', () => {
 	test('should perform autocomplete', async () => {
 		let endpoint = 'http://127.0.0.1:11434';
 		let model = 'codellama:7b-code-q4_K_S'; // Lightweight llm for tests
+		let maxLines = 16;
+		let maxTokens = 256;
 		let prompt = 'fun main(): ';
 		let result = await autocomplete({
 			endpoint,
 			model,
 			prefix: prompt,
-			suffix: ''
+			suffix: '',
+			maxLines,
+			maxTokens
 		});
 		console.warn(result);
 	});

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -19,6 +19,7 @@ suite('Extension Test Suite', () => {
 		let model = 'codellama:7b-code-q4_K_S'; // Lightweight llm for tests
 		let maxLines = 16;
 		let maxTokens = 256;
+		let temperature = 0.2;
 		let prompt = 'fun main(): ';
 		let result = await autocomplete({
 			endpoint,
@@ -26,7 +27,8 @@ suite('Extension Test Suite', () => {
 			prefix: prompt,
 			suffix: '',
 			maxLines,
-			maxTokens
+			maxTokens,
+			temperature
 		});
 		console.warn(result);
 	});


### PR DESCRIPTION
- Introduce 'maxLines' and 'maxTokens' configurations to provide finer control over the inference engine
- Introduce 'temperature' configuration to control the creativity level of model responses (lower is better in coding and by default ollama use 0.8)