### PR TITLE
Add example for inference.endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
           "inference.endpoint": {
             "type": "string",
             "default": "",
-            "description": "Ollama Server Endpoint. Empty for local instance.",
+            "description": "Ollama Server Endpoint. Empty for local instance. Example: http://192.168.0.100:11434",
             "order": 1
           },
           "inference.model": {


### PR DESCRIPTION
It took me a bit of trial and error to figure out the expected format so I figured it may be worthwhile to have an example in the settings.