### PR TITLE
Added space in prompt for better infills and proper stop token

### DIFF
--- a/src/prompts/processors/models.ts
+++ b/src/prompts/processors/models.ts
@@ -19,7 +19,7 @@ export function adaptPrompt(args: { format: ModelFormat, prefix: string, suffix:
     }
 
     // Stable code FIM
-    if (args.format === 'stable-code')  {
+    if (args.format === 'stable-code') {
         return {
             prompt: `<fim_prefix>${args.prefix}<fim_suffix>${args.suffix}<fim_middle>`,
             stop: [`<|endoftext|>`]
@@ -28,7 +28,7 @@ export function adaptPrompt(args: { format: ModelFormat, prefix: string, suffix:
 
     // Codellama FIM
     return {
-        prompt: `<PRE> ${args.prefix} <SUF>${args.suffix} <MID>`,
-        stop: [`<PRE>`, `<SUF>`, `<MID>`, `<END>`]
+        prompt: `<PRE> ${args.prefix} <SUF> ${args.suffix} <MID>`,
+        stop: [`<END>`, `<EOD>`, `<EOT>`]
     };
 }


### PR DESCRIPTION
Hi!

I've been experimenting with CodeLlama FIM last couple of days. What I discovered is that CodeLlama gives more robust results when sentinel tokens in prompt is surrounded by spaces. It's especially noticeable at the beginning of the file when 'system' part of prefix dominates the prompt.

Typical failure is shown below:
![before](https://github.com/ex3ndr/llama-coder/assets/15689588/9837f1ee-148e-4107-ae4b-1bb220a59728)

After the fix model fills the code properly:
![after](https://github.com/ex3ndr/llama-coder/assets/15689588/f3deaf7f-7331-448b-a203-ae2010049b15)

I also changed stop tokens. I added `<EOT>` and `<EOD>` according to the paper and removed `<PRE>`, `<SUF>` and `<MID>` tokens since they stopped showing up in model responses after I fixed the prompt.