### PR TITLE
Added option to delay completion request

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,14 @@
             "default": 256,
             "description": "Max number of new tokens to be generated.",
             "order": 7
+          },
+          "inference.delay": {
+            "type": "number",
+            "default": 250,
+            "description": "Completion request delay in milliseconds (0 - no delay, -1 - no completions).",
+            "order": 8,
+            "minimum": -1,
+            "maximum": 5000
           }
         }
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,13 +35,16 @@ class Config {
             }
         }
 
+        let delay = config.get('delay') as number;
+
         return {
             endpoint,
             maxLines,
             maxTokens,
             temperature,
             modelName,
-            modelFormat
+            modelFormat,
+            delay
         };
     }
 

--- a/src/prompts/provider.ts
+++ b/src/prompts/provider.ts
@@ -20,7 +20,21 @@ export class PromptProvider implements vscode.InlineCompletionItemProvider {
         this.context = context;
     }
 
+    async delayCompletion(delay: number, token: vscode.CancellationToken): Promise<boolean> {
+        if (config.inference.delay < 0) {
+            return false;
+        }
+        await new Promise(p => setTimeout(p, delay));
+        if (token.isCancellationRequested) {
+            return false;
+        }
+        return true;
+    }
+
     async provideInlineCompletionItems(document: vscode.TextDocument, position: vscode.Position, context: vscode.InlineCompletionContext, token: vscode.CancellationToken): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList | undefined | null> {
+        if (!await this.delayCompletion(config.inference.delay, token)) {
+            return;
+        }
 
         try {
 
@@ -66,15 +80,6 @@ export class PromptProvider implements vscode.InlineCompletionItemProvider {
 
                     // Config
                     let inferenceConfig = config.inference;
-                    // let config = vscode.workspace.getConfiguration('inference');
-                    // let endpoint = config.get('endpoint') as string;
-                    // let model = config.get('model') as string;
-                    // let maxLines = config.get('maxLines') as number;
-                    // let maxTokens = config.get('maxTokens') as number;
-                    // let temperature = config.get('temperature') as number;
-                    // if (endpoint.endsWith('/')) {
-                    //     endpoint = endpoint.slice(0, endpoint.length - 1);
-                    // }
 
                     // Update status
                     this.statusbar.text = `$(sync~spin) Llama Coder`;


### PR DESCRIPTION
Closes #19 

Implemented delay between firing inline completion event from VSCode and inference logic to avoid unnecessary completion requests (i.e. when user is typing).

Added corresponding option to extension's settings (250ms seems perfect to me).
