### PR TITLE
Feature: Pause Autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,24 @@
   "extensionKind": ["ui"],
   "main": "./out/extension.js",
   "contributes": {
+    "commands": [
+      {
+        "command": "llama.openSettings",
+        "title": "Llama Coder: Open Settings"
+      },
+      {
+        "command": "llama.pause",
+        "title": "Llama Coder: Pause"
+      },
+      {
+        "command": "llama.resume",
+        "title": "Llama Coder: Resume"
+      },
+      {
+        "command": "llama.toggle",
+        "title": "Llama Coder: Toggle"
+      }
+    ],
     "configuration": [
       {
         "title": "Llama coder",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,12 +9,12 @@ export function activate(context: vscode.ExtensionContext) {
 	info('Llama Coder is activated.');
 
 	// Create status bar
-	const openSettings = 'llama.openSettings';
-	context.subscriptions.push(vscode.commands.registerCommand(openSettings, () => {
+	context.subscriptions.push(vscode.commands.registerCommand('llama.openSettings', () => {
 		vscode.commands.executeCommand('workbench.action.openSettings', '@ext:ex3ndr.llama-coder');
 	}));
+
 	let statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
-	statusBarItem.command = openSettings;
+	statusBarItem.command = 'llama.toggle';
 	statusBarItem.text = `$(chip) Llama Coder`;
 	statusBarItem.show();
 	context.subscriptions.push(statusBarItem);
@@ -23,6 +23,17 @@ export function activate(context: vscode.ExtensionContext) {
 	const provider = new PromptProvider(statusBarItem, context);
 	let disposable = vscode.languages.registerInlineCompletionItemProvider({ pattern: '**', }, provider);
 	context.subscriptions.push(disposable);
+
+	context.subscriptions.push(vscode.commands.registerCommand('llama.pause', () => {
+		provider.paused = true;
+	}));
+	context.subscriptions.push(vscode.commands.registerCommand('llama.resume', () => {
+		provider.paused = false;
+	}));
+	context.subscriptions.push(vscode.commands.registerCommand('llama.toggle', () => {
+		provider.paused = !provider.paused;
+	}));
+
 }
 
 export function deactivate() {


### PR DESCRIPTION
This patch allows the user to pause/resume autocomplete (#13) for the duration of the Visual Studio Code session.  The status bar item indicates that autocomplete is paused through the displayed icon as well as the tooltip.

Additional changes
- New: Added command `llama.pause`, "Llama Coder: Pause" -- pause autocomplete until resumed or the session is restarted.
- New: Added command `llama.resume`, "Llama Coder: Resume" -- resume autocomplete after being previously paused.
- New: Added command `llama.toggle`, "Llama Coder: Toggle" -- toggle the paused state of inferencing.
- Change: Modified command `llama.openSettings` now available in the command palette as "Llama Coder: Open Settings".
- Change: Clicking on the status bar item will invoke `llama.toggle` instead of `llama.openSettings`.
