### PR TITLE
Allow manual completions even when inference.delay is -1

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
           "inference.delay": {
             "type": "number",
             "default": 250,
-            "description": "Completion request delay in milliseconds (0 - no delay, -1 - no completions).",
+            "description": "Completion request delay in milliseconds (0 - no delay, -1 - no automatic completions).",
             "order": 8,
             "minimum": -1,
             "maximum": 5000

--- a/src/prompts/provider.ts
+++ b/src/prompts/provider.ts
@@ -26,7 +26,7 @@ export class PromptProvider implements vscode.InlineCompletionItemProvider {
         this.statusbar = statusbar;
         this.context = context;
     }
-    
+
     public set paused(value: boolean) {
         this._paused = value;
         this.update();
@@ -65,7 +65,7 @@ export class PromptProvider implements vscode.InlineCompletionItemProvider {
     }
 
     async provideInlineCompletionItems(document: vscode.TextDocument, position: vscode.Position, context: vscode.InlineCompletionContext, token: vscode.CancellationToken): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList | undefined | null> {
-        if (!await this.delayCompletion(config.inference.delay, token)) {
+        if (context.triggerKind !== vscode.InlineCompletionTriggerKind.Invoke && !await this.delayCompletion(config.inference.delay, token)) {
             return;
         }
 


### PR DESCRIPTION
Adds a check to provideInlineCompletionItems which skips the delay call if the completion was triggered manually (such as by using the built-in 'Trigger inline suggestion' action).

This allows automatic completions to be disabled while still allowing manual completions.