### PR TITLE
fix: config modelFormat typo

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ class Config {
         let modelFormat: ModelFormat = 'codellama';
         if (modelName === 'custom') {
             modelName = config.get('custom.model') as string;
-            modelFormat = config.get('cutom.format') as ModelFormat;
+            modelFormat = config.get('custom.format') as ModelFormat;
         } else {
             if (modelName.startsWith('deepseek-coder')) {
                 modelFormat = 'deepseek';


### PR DESCRIPTION
While testing #54 I noticed a typo in the config code, which actually caused the modelFormat to be incorrect when setting a custom type.

Fixed the typo, so hopefully the gemmacode logic from #54 can be accepted as well.